### PR TITLE
GCS Backend: minor fixes for auth when using role with AAP controller

### DIFF
--- a/roles/gcs_backend/README.md
+++ b/roles/gcs_backend/README.md
@@ -16,6 +16,10 @@ gcs_backend_auth_kind|The type of credential used. Choices: 'application', 'serv
 gcs_backend_service_account_file|The path of a Service Account JSON file if serviceaccount is selected as authentication type.|string|N/A| when `gcs_backend_auth_kind = serviceaccount`
 gcs_backend_service_account_email|An optional service account email address if machineaccount is selected and the user does not wish to use the default email.|string|N/A| No
 
+### Using with AAP Controller
+
+Note: When using this role in AAP Controller, authentication to Google Cloud Platform (GCP) can be performed by adding GCE type credentials in AAP Controller and providing it to the job template that makes use of this role.
+In such case, `gcs_backend_service_account_file` and `gcs_backend_service_account_email` role variables can be omitted.
 
 ## Examples
 ```

--- a/roles/gcs_backend/README.md
+++ b/roles/gcs_backend/README.md
@@ -16,10 +16,9 @@ gcs_backend_auth_kind|The type of credential used. Choices: 'application', 'serv
 gcs_backend_service_account_file|The path of a Service Account JSON file if serviceaccount is selected as authentication type.|string|N/A| when `gcs_backend_auth_kind = serviceaccount`
 gcs_backend_service_account_email|An optional service account email address if machineaccount is selected and the user does not wish to use the default email.|string|N/A| No
 
-### Using with AAP Controller
+### Using with Ansible Automation Platform (AAP)
 
-Note: When using this role in AAP Controller, authentication to Google Cloud Platform (GCP) can be performed by adding GCE type credentials in AAP Controller and providing it to the job template that makes use of this role.
-In such case, `gcs_backend_service_account_file` and `gcs_backend_service_account_email` role variables can be omitted.
+Note: When using this role in AAP, authentication to Google Cloud Platform (GCP) can be performed by adding GCE type credentials in AAP and providing it to the job template that makes use of this role.
 
 ## Examples
 ```

--- a/roles/gcs_backend/tasks/create.yml
+++ b/roles/gcs_backend/tasks/create.yml
@@ -6,5 +6,6 @@
       enabled: true
     project: "{{ gcs_backend_gcp_project }}"
     auth_kind: "{{ gcs_backend_auth_kind }}"
-    service_account_file: "{{ gcs_backend_service_account_file }}"
+    service_account_file: "{{ gcs_backend_service_account_file | default(omit) }}"
+    service_account_email: "{{ gcs_backend_service_account_email | default(omit) }}"
     state: present

--- a/roles/gcs_backend/tasks/create.yml
+++ b/roles/gcs_backend/tasks/create.yml
@@ -4,8 +4,8 @@
     name: "{{ gcs_backend_bucket_name }}"
     versioning:
       enabled: true
-    project: "{{ gcs_backend_gcp_project }}"
-    auth_kind: "{{ gcs_backend_auth_kind }}"
+    project: "{{ gcs_backend_gcp_project | default(omit) }}"
+    auth_kind: "{{ gcs_backend_auth_kind | default(omit) }}"
     service_account_file: "{{ gcs_backend_service_account_file | default(omit) }}"
     service_account_email: "{{ gcs_backend_service_account_email | default(omit) }}"
     state: present

--- a/roles/gcs_backend/tasks/delete.yml
+++ b/roles/gcs_backend/tasks/delete.yml
@@ -4,7 +4,8 @@
     name: "{{ gcs_backend_bucket_name }}"
     project: "{{ gcs_backend_gcp_project }}"
     auth_kind: "{{ gcs_backend_auth_kind }}"
-    service_account_file: "{{ gcs_backend_service_account_file }}"
+    service_account_file: "{{ gcs_backend_service_account_file | default(omit) }}"
+    service_account_email: "{{ gcs_backend_service_account_email | default(omit) }}"
     state: absent
   ignore_errors: true  # currently module `gcp_storage_bucket` does not support deleting non-empty buckets
   register: delete_bucket_result

--- a/roles/gcs_backend/tasks/delete.yml
+++ b/roles/gcs_backend/tasks/delete.yml
@@ -2,8 +2,8 @@
 - name: Delete a storage bucket
   google.cloud.gcp_storage_bucket:
     name: "{{ gcs_backend_bucket_name }}"
-    project: "{{ gcs_backend_gcp_project }}"
-    auth_kind: "{{ gcs_backend_auth_kind }}"
+    project: "{{ gcs_backend_gcp_project | default(omit) }}"
+    auth_kind: "{{ gcs_backend_auth_kind | default(omit) }}"
     service_account_file: "{{ gcs_backend_service_account_file | default(omit) }}"
     service_account_email: "{{ gcs_backend_service_account_email | default(omit) }}"
     state: absent


### PR DESCRIPTION
gcs_backend role can be used with AAP Controller without providing `service_account_file` and `service_account_email`.
This requires adding GCE credentials in the controller and providing that to job template.

This PR makes minor fixes and updates readme to reflect the above.